### PR TITLE
Remove merge diff meta (can't load unpacked extension)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,8 @@
 {
   "manifest_version": 2,
 
-<<<<<<< HEAD
   "name": "Cast Rocket for Plex",
   "version": "1.2.4",
-=======
-  "name": "Plex Cast",
-  "version": "1.2.3",
->>>>>>> origin/master
   "description": "Cast almost any online video from your browser to your Plex device! Includes a remote to control your devices.",
 
   "browser_action": {


### PR DESCRIPTION
There was some diff meta accidentally left in the `manifest.json`, which caused the extension to fail loading in Chrome.
